### PR TITLE
fix: Update cd.yml to run build script

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,4 +19,4 @@ jobs:
                 go-version: "1.23.0"
             
             - name: Build Notely app
-              uses: ./scripts/buildprod.sh
+              run: ./scripts/buildprod.sh


### PR DESCRIPTION
- Replace `uses` with `run` to correctly execute the script
- This resolves a syntax error with running the Deploy job